### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ add xml namespace to access custom properties, add following line to your root v
 ```xmlns:app='http://schemas.android.com/apk/res-auto' ```
 
 
-####2.1. Setup ImageFrame.
+#### 2.1. Setup ImageFrame.
 ```
   <com.kgkg.imagevieweffects.ImageFrame
     android:layout_width='wrap_content'
@@ -41,7 +41,7 @@ add xml namespace to access custom properties, add following line to your root v
   app:mMaskOpacity="0.5"/>
   ```
 
-####2.3. Setup mask
+#### 2.3. Setup mask
 ```
 <com.kgkg.imagevieweffects.ImageTitle
   android:id="@+id/titleBlock"
@@ -58,7 +58,7 @@ add xml namespace to access custom properties, add following line to your root v
   app:mEffectDirection="left"/>
 ```
     
-##3. Set effect listener
+## 3. Set effect listener
 ```
 IOnPlayEffect listener = new IOnPlayEffect() {
     @Override


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
